### PR TITLE
Remove Babel configuration file

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  presets: [
-    'next/babel'
-  ],
-};


### PR DESCRIPTION
This pull request includes a small change to the `babel.config.js` file. The change removes the configuration for Babel, which previously used the `next/babel` preset.